### PR TITLE
Add Table callback

### DIFF
--- a/src/TextTabulator/README.md
+++ b/src/TextTabulator/README.md
@@ -31,7 +31,7 @@ var values = new string[][]
    new string[] { "value1C", "value2C", "value3C", },
 };
 
-var tabulator = new TextTabulator();
+var tabulator = new Tabulator();
 
 var table = tabulator.Tabulate(headers, values);
 
@@ -39,6 +39,7 @@ Console.WriteLine(table);
 ```
 
 The output of the above code would be:
+
 ```
 -------------------------
 |Header1|Header2|Header3|
@@ -51,55 +52,241 @@ The output of the above code would be:
 -------------------------
 ```
 
-## Overloads
+## Public API
 
-The `Tabulator.Tabulate` method is overloaded. It can be called with collections of `string` types, `object` types, or `CellValue` delegate types. All three additionally have overloads with or without headers.
+### `TextTabulator.Tabulator` class
 
-A final category of overload accepts an `ITabulatorAdapter` interface.
+The `TextTabulator.Tabulator` class has several overloaded `Tabulate` methods that generate the table.
 
-### String type overloads
+**Methods**
 
-```
-public string Tabulate(IEnumerable<IEnumerable<string>> rowValues, TabulatorOptions? options = null)
-public string Tabulate(IEnumerable<string> headers, IEnumerable<IEnumerable<string>> rowValues, TabulatorOptions? options = null)
-```
+#### `public string Tabulate(IEnumerable<IEnumerable<string>> rowValues, TabulatorOptions? options = null)`
 
-For the `string` type overloads, the value of each string object will be used as each cell's content. Each `string` will be read once for each call to `Tabulator.Tabulate`.
+Tabulates data and outputs a string representation of a table.
 
-### Object type overloads
+Parameters
 
-```
-public string Tabulate(IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)
-public string Tabulate(IEnumerable<object> headers, IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)
-```
+- `IEnumerable<IEnumerable<string>> rowValues`: Enumeration containing strings for each header.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
 
-For the `object` type overloads, the type's `ToString` method will be called to generate the content of the cell. Each `object` will have its `ToString` method called once for each call to `Tabulator.Tabulate`.
+Return
 
-### CellValue delegate type overloads
+- `string`: String representation of a table.
 
-```
-public string Tabulate(IEnumerable<IEnumerable<CellValue>> rowValues, TabulatorOptions? options = null);
-public string Tabulate(IEnumerable<CellValue> headers, IEnumerable<IEnumerable<CellValue>> rowValues, TabulatorOptions? options = null)
-```
+#### `public string Tabulate(IEnumerable<string> headers, IEnumerable<IEnumerable<string>> rowValues, TabulatorOptions? options = null)`
 
-For the `CellValue` delegate type overloads, the delegate will be invoked to generate the content of the cell. It can be used to generate content dynamically. Each `CellValue` will be invoked only once per call to `Tabulator.Tabulate`.
+Tabulates data and outputs a string representation of a table.
 
-The delegate `CellValue` has the signature:
+Parameters
+
+- `IEnumerable<string> headers`: Enumeration containing strings for each header.
+- `IEnumerable<IEnumerable<string>> rowValues`: Enumeration containing strings for each header.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public string Tabulate(IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)`
+
+Tabulates data and outputs a string representation of a table.
+
+Parameters
+
+- `IEnumerable<IEnumerable<object>> rowValues`: Enumeration containing strings for each header. Each object's ToString() method will be called to generate the value displayed in the table.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public string Tabulate(IEnumerable<object> headers, IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)`
+
+Tabulates data and outputs a string representation of a table.
+
+Parameters
+
+- `IEnumerable<object> headers`: Enumeration containing objects for each header. Each object's ToString() method will be called to generate the value displayed in the table.
+- `IEnumerable<IEnumerable<object>> rowValues`: Enumeration containing strings for each header. Each object's ToString() method will be called to generate the value displayed in the table.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public string Tabulate(IEnumerable<IEnumerable<CellValue>> rowValues, TabulatorOptions? options = null)`
+
+Tabulates data and outputs a string representation of a table.
+
+Parameters
+
+- `IEnumerable<IEnumerable<CellValue>> rowValues`: Enumeration containing `CellValue` delegates for each value in each row.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public string Tabulate(IEnumerable<CellValue> headers, IEnumerable<IEnumerable<CellValue>> rowValues, TabulatorOptions? options = null)`
+
+Tabulates data and outputs a string representation of a table.
+
+Parameters
+
+- `IEnumerable<CellValue> headers`: Enumeration containing `CellValue` delegates for each header.
+- `IEnumerable<IEnumerable<CellValue>> rowValues`: Enumeration containing `CellValue` delegates for each value in each row.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public string Tabulate(ITabulatorAdapter adapter, TabulatorOptions? options = null)`
+
+Tabulates data and outputs a string representation of a table.
+
+Parameters
+
+- `ITabulatorAdapter adapter`: Adapter object that the method can get data from.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- `string`: String representation of a table.
+
+#### `public void Tabulate(IEnumerable<IEnumerable<string>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<IEnumerable<string>> rowValues`: Enumeration containing strings for each header.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(IEnumerable<string> headers, IEnumerable<IEnumerable<string>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<string> headers`: Enumeration containing strings for each header.
+- `IEnumerable<IEnumerable<string>> rowValues`: Enumeration containing strings for each header.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(IEnumerable<IEnumerable<object>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<IEnumerable<object>> rowValues`: Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(IEnumerable<object> headers, IEnumerable<IEnumerable<object>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<object> headers`: Enumeration containing strings for each header. Each object's ToString() method will be called to generate the value displayed in the table.
+- `IEnumerable<IEnumerable<object>> rowValues`: Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(IEnumerable<IEnumerable<CellValue>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<IEnumerable<CellValue>> rowValues`: Enumeration containing `CellValue` delegates for each value in each row.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(IEnumerable<CellValue> headers, IEnumerable<IEnumerable<CellValue>> rowValues, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `IEnumerable<CellValue> headers`: Enumeration containing `CellValue` delegates for each header.
+- `IEnumerable<IEnumerable<CellValue>> rowValues`: Enumeration containing `CellValue` delegates for each value in each row.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+#### `public void Tabulate(ITabulatorAdapter adapter, TableCallback callback, TabulatorOptions? options = null)`
+
+Tabulates data and makes callbacks with elements of the table.
+
+Parameters
+
+- `ITabulatorAdapter adapter`: Adapter object that the method can get data from.
+- `TableCallback callback`: Callback received when an element of the table is constructed.
+- `TabulatorOptions? options`: Options specifying how the table should be constructed.
+
+Return
+
+- None
+
+### Delegates
+
+`TextTabulator` defines some delegates that can be passed to `Tabulator.Tabulate`.
+
+#### `CellValue`
+
+Used in some overloads of `TextTabulator.Tabulate` to dynamically generate table data. The delegate is called when the content of each cell is generated. Implementers should return the string representation of the value in the table.
+
+Signature:
 
 ```
 public delegate string CellValue();
 ```
 
+#### `TableCallback`
 
-### `ITabulatorAdapter` type overloads
+Used in some overloads of `TextTabulator.Tabulate` so that the caller can receive callbacks when elements of the table are generated. This can be used to put pieces of the table directly into other outputs more efficiently. The parameter `string text` will contain the most recently created element of the table.
 
+Signature:
 ```
-public string Tabulte(ITabulatorAdapter adapter, TabulatorOptions? options = null)
+public delegate void TableCallback(string text);
 ```
 
-This overload allows `Tabulator.Tabulate` to more easily integrate with other types of formats of data. Currently supported adapters include CSV and reflection over objects. More information can be found in each adapter's project:
+### Adapters
+
+`TextTabulator` exposes the interface `ITabulatorAdapter`, which can be implemented to allow the `Tabulator.Tabulate` method to consume different types of data. There are existing implementations available for popular data types. Alternatively, this interface can be used to provide a custom implementation.
+
+Existing implementations are distributed in separate Nuget packages. More information can be found in their respective projects.
+
 - [CsvHelper adapter](../TextTabulator.Adapters.CsvHelper/README.md)
 - [JSON adapter](../TextTabulator.Adapters.Json/README.md)
+- [XML adapter](../TextTabulator.Adapters.Xml/README.md)
 - [Reflection adapter](../TextTabulator.Adapters.Reflection/README.md)
 
 ## Tabulation Options

--- a/src/TextTabulator/TableCallback.cs
+++ b/src/TextTabulator/TableCallback.cs
@@ -1,0 +1,8 @@
+﻿namespace TextTabulator
+{
+    /// <summary>
+    /// Delegate for receiving callbacks when elements of the table are constructed.
+    /// </summary>
+    /// <param name="text">The most recently constructed element of the table.</param>
+    public delegate void TableCallback(string text);
+}

--- a/src/TextTabulator/Tabulator.cs
+++ b/src/TextTabulator/Tabulator.cs
@@ -14,6 +14,103 @@ namespace TextTabulator
         private readonly ITableDataParser _tableDataParser = new TableDataParser();
 
         /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="adapter">Adapter object that the method can get data from.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(ITabulatorAdapter adapter, TableCallback callback, TabulatorOptions? options = null)
+        {
+            var headers = adapter.GetHeaderStrings() ?? Array.Empty<string>();
+            var values = adapter.GetValueStrings();
+
+            Tabulate(headers, values, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="rowValues">Enumeration containing CellValues delegates for each value in each row.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<IEnumerable<CellValue>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            var rowValueStrings = rowValues.Select(i => i.Select(j => j.Invoke()));
+
+            Tabulate(Array.Empty<string>(), rowValueStrings, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="headers">Enumeration containing CellValues delegates for each header.</param>
+        /// <param name="rowValues">Enumeration containing CellValues delegates for each value in each row.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<CellValue> headers, IEnumerable<IEnumerable<CellValue>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            var headerStrings = headers.Select(i => i.Invoke());
+            var rowValueStrings = rowValues.Select(i => i.Select(j => j.Invoke()));
+
+            Tabulate(headerStrings, rowValueStrings, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="rowValues">Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<IEnumerable<object>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            var rowValueStrings = rowValues.Select(i => i.Select(j => j.ToString()));
+
+            Tabulate(Array.Empty<string>(), rowValueStrings, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="headers">Enumeration containing objects for each header. Each object's ToString() method will be called to generate the value displayed in the table.</param>
+        /// <param name="rowValues">Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<object> headers, IEnumerable<IEnumerable<object>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            var headerStrings = headers.Select(i => i.ToString());
+            var rowValueStrings = rowValues.Select(i => i.Select(j => j.ToString()));
+
+            Tabulate(headerStrings, rowValueStrings, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="rowValues">Enumeration containing strings for each value in each row.</param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<IEnumerable<string>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            Tabulate(Array.Empty<string>(), rowValues, callback, options);
+        }
+
+        /// <summary>
+        /// Tabulates data and makes callbacks with elements of the table.
+        /// </summary>
+        /// <param name="headers">Enumeration containing strings for each header.</param>
+        /// <param name="rowValues"></param>
+        /// <param name="callback">Callback received when an element of the table is constructed.</param>
+        /// <param name="options">Options specifying how the table should be constructed.</param>
+        public void Tabulate(IEnumerable<string> headers, IEnumerable<IEnumerable<string>> rowValues, TableCallback callback, TabulatorOptions? options = null)
+        {
+            options ??= new TabulatorOptions();
+
+            var tableData = _tableDataParser.Parse(headers, rowValues);
+
+            TabulateData(tableData, callback, options);
+        }
+
+        /// <summary>
         /// Tabulates data and outputs a string representation of a table.
         /// </summary>
         /// <param name="adapter">Adapter object that the method can get data from.</param>
@@ -58,7 +155,7 @@ namespace TextTabulator
         /// <summary>
         /// Tabulates data and outputs a string representation of a table.
         /// </summary>
-        /// <param name="rowValues">Enumeration containing objects for each value in each row.</param>
+        /// <param name="rowValues">Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.</param>
         /// <param name="options">Options specifying how the table should be constructed.</param>
         /// <returns>String representation of a table.</returns>
         public string Tabulate(IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)
@@ -71,8 +168,8 @@ namespace TextTabulator
         /// <summary>
         /// Tabulates data and outputs a string representation of a table.
         /// </summary>
-        /// <param name="headers">Enumeration containing objects for each header.</param>
-        /// <param name="rowValues">Enumeration containing objects for each value in each row.</param>
+        /// <param name="headers">Enumeration containing objects for each header. Each object's ToString() method will be called to generate the value displayed in the table.</param>
+        /// <param name="rowValues">Enumeration containing objects for each value in each row. Each object's ToString() method will be called to generate the value displayed in the table.</param>
         /// <param name="options">Options specifying how the table should be constructed.</param>
         /// <returns>String representation of a table.</returns>
         public string Tabulate(IEnumerable<object> headers, IEnumerable<IEnumerable<object>> rowValues, TabulatorOptions? options = null)
@@ -108,24 +205,26 @@ namespace TextTabulator
 
             var tableData = _tableDataParser.Parse(headers, rowValues);
 
-            return TabulateData(tableData, options);
+            var table = new StringBuilder();
+
+            TabulateData(tableData, t => table.Append(t), options);
+
+            return table.ToString();
         }
 
-        private string TabulateData(ITableData tableData, TabulatorOptions options)
+        private void TabulateData(ITableData tableData, TableCallback callback, TabulatorOptions options)
         {
             var hasHeaders = !(tableData.Headers == null || tableData.Headers.Cells == null || tableData.Headers.Cells.Count == 0);
             var hasRowValues = !(tableData.ValueRows == null || tableData.ValueRows.Count == 0);
 
             if (!hasHeaders && !hasRowValues)
             {
-                return string.Empty;
+                return;
             }
-
-            var table = new StringBuilder();
 
             // Start with the top edge of the table.
             var topEdge = BuildTopEdge(tableData, options);
-            table.Append(topEdge + options.NewLine);
+            callback.Invoke(topEdge + options.NewLine);
 
             var middleRowSeparator = BuildRowSeparator(tableData, options, false);
 
@@ -133,12 +232,12 @@ namespace TextTabulator
             {
                 // Add the header row.
                 var headerRow = BuildRowHeaders(tableData, options);
-                table.Append(headerRow + options.NewLine);
+                callback.Invoke(headerRow + options.NewLine);
 
                 if (hasRowValues)
                 {
                     var headerRowSeparator = BuildRowSeparator(tableData, options, true);
-                    table.Append(headerRowSeparator + options.NewLine);
+                    callback.Invoke(headerRowSeparator + options.NewLine);
                 }
             }
 
@@ -146,19 +245,19 @@ namespace TextTabulator
             {
                 // Add the row values.
                 var rowString = BuildRowValues(tableData.ValueRows[i], tableData.MaxColumnWidths, options);
-                table.Append(rowString + options.NewLine);
+                callback.Invoke(rowString + options.NewLine);
 
                 if (i < tableData.ValueRows.Count - 1)
                 {
                     // Add the row separator.
-                    table.Append(middleRowSeparator + options.NewLine);
+                    callback.Invoke(middleRowSeparator + options.NewLine);
                 }
             }
 
             var bottomEdge = BuildBottomEdge(tableData, options);
-            table.Append(bottomEdge + options.NewLine);
+            callback.Invoke(bottomEdge + options.NewLine);
 
-            return table.ToString();
+            return;
         }
 
         private string BuildTopEdge(ITableData tableData, TabulatorOptions options)

--- a/tests/TextTabulatorTests/TabulatorTests.cs
+++ b/tests/TextTabulatorTests/TabulatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using NSubstitute;
+using System.Text;
 using TextTabulator;
 using TextTabulator.Adapters;
 
@@ -436,7 +437,7 @@ namespace TextTabulatorTests
         }
 
         [Fact]
-        public void When_tabulate_called_with_tablevalue_delegates_for_multiple_headers_and_multiple_rows_then_table_returned()
+        public void When_tabulate_called_with_cellvalue_delegates_for_multiple_headers_and_multiple_rows_then_table_returned()
         {
             var headers = new CellValue[]
             {
@@ -472,7 +473,7 @@ namespace TextTabulatorTests
         }
 
         [Fact]
-        public void When_tabulate_called_with_tablevalue_delegates_for_multiple_rows_then_table_returned()
+        public void When_tabulate_called_with_cellvalue_delegates_for_multiple_rows_then_table_returned()
         {
             var values = new CellValue[][]
             {
@@ -1291,6 +1292,71 @@ namespace TextTabulatorTests
             var sut = new Tabulator();
 
             var table = sut.Tabulate(headers, values, new TabulatorOptions { NewLine = "\r\n" });
+
+            Assert.Equal(expected, table);
+        }
+
+        [Fact]
+        public void When_tabulate_called_with_tablecallback_delegates_for_multiple_headers_and_multiple_rows_then_table_returned()
+        {
+            var headers = new CellValue[]
+            {
+                () => "Header1",
+                () => "Header2",
+                () => "Header3",
+            };
+
+            var values = new CellValue[][]
+            {
+                new CellValue [] { () => "value1A", () => "value1B", () => "value1C" },
+                new CellValue [] { () => "value2A", () => "value2B", () => "value2C" },
+                new CellValue [] { () => "value3A", () => "value3B", () => "value3C" },
+            };
+
+            var expected =
+@$"-------------------------
+|{headers[0]()}|{headers[1]()}|{headers[2]()}|
+|-------+-------+-------|
+|{values[0][0]()}|{values[0][1]()}|{values[0][2]()}|
+|-------+-------+-------|
+|{values[1][0]()}|{values[1][1]()}|{values[1][2]()}|
+|-------+-------+-------|
+|{values[2][0]()}|{values[2][1]()}|{values[2][2]()}|
+-------------------------
+";
+
+            var sut = new Tabulator();
+
+            var table = new StringBuilder();
+            
+            sut.Tabulate(headers, values, t => table.Append(t), new TabulatorOptions { NewLine = "\r\n" });
+
+            Assert.Equal(expected, table.ToString());
+        }
+
+        [Fact]
+        public void When_tabulate_called_with_tablecallback_delegates_for_multiple_rows_then_table_returned()
+        {
+            var values = new string[][]
+            {
+                new string [] { "value1A", "value1B", "value1C" },
+                new string [] { "value2A", "value2B", "value2C" },
+                new string [] { "value3A", "value3B", "value3C" }
+            };
+
+            var expected =
+@$"-------------------------
+|{values[0][0]}|{values[0][1]}|{values[0][2]}|
+|-------+-------+-------|
+|{values[1][0]}|{values[1][1]}|{values[1][2]}|
+|-------+-------+-------|
+|{values[2][0]}|{values[2][1]}|{values[2][2]}|
+-------------------------
+";
+
+            var sut = new Tabulator();
+
+            var table = sut.Tabulate(values, new TabulatorOptions { NewLine = "\r\n" });
 
             Assert.Equal(expected, table);
         }


### PR DESCRIPTION
Add support for `TableCallback` delegate, which allows the caller of `Tabulator.Tabulate` to receive callbacks when an new element of the table is created.

Updated and restructured documentation.